### PR TITLE
fix typo in meta tags

### DIFF
--- a/_layouts/main.html
+++ b/_layouts/main.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="description" content="{{page.description}}">
     <meta name="keywords" content="{{page.keywords}}">
-    <meta property="og:title" content="Signak K &raquo; {{page.title}}">
+    <meta property="og:title" content="Signal K &raquo; {{page.title}}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{site.url}}/{{site.path}}/{{page.url}}">
     <meta property="og:image" content="{{site.url}}/{{site.path}}/{{site.logo}}">


### PR DESCRIPTION
`Signak K` ➡️  `Signal K`