### PR TITLE
update team, contact info

### DIFF
--- a/about.html
+++ b/about.html
@@ -8,103 +8,28 @@ description: Meet the team
 <h2>How it All Began</h2>
 
 <p>
-  Signal K began in a GitHub issue, as a solution for 5 developers to make their projects interoperable. Frustrated at
+  Signal K began in <a href="https://github.com/tkurki/navgauge/issues/4">GitHub issue</a>, as a solution for 5 developers to make their projects interoperable. Frustrated at
   the closed protocols, expensive hardware and internet “unfriendliness” of marine data, they decided to develop a new
   “Open Data Standard” that would compliment and expand the existing marine data protocols.
 </p>
 <p>
   By utilising modern web technologies and protocols, running on low cost but powerful hardware platforms and
   encouraging an open and collaborative community of developers all working to a common goal, they have managed to
-  create a really powerful and expandable data format, that will change the marine electronics market forever.
+  create a really powerful and expandable data format, that keeps changing the marine electronics ecosystem in a more open direction.
 </p>
 
-<h2>Meet the Team</h2>
+<h2>The Team</h2>
 
-<p>
-  Although the number of contributors and developers has significantly increased over the last few years, the core team
-  of 5 developers and 1 installer/writer that made it all happen, are still actively involved and making sure their
-  “baby” is growing as it should:
-</p>
-
-<ul class="team-grid">
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Robert Huitema" src="{{site.path}}/images/rob_s.jpg" height="190" width="190">
-    </div>
-    <h4 class="name">Robert Huitema</h4>
-    <p>
-      Sailing since early 90s. Spent 2 years sailing the Pacific Islands and Australia with my family. While cruising,
-      began using an Arduino for various onboard tasks, and in 2011 started the
-      <a href="http://www.42.co.nz/freeboard/">Freeboard project</a>.
-    </p>
-  </li>
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Teppo Kurki" src="https://avatars0.githubusercontent.com/u/1049678?v=3&s=190" height="190" width="190">
-    </div>
-    <h4 class="name">Teppo Kurki</h4>
-    <p>
-      Cruises the Baltic on a Raspberry Pi equipped sailboat and helps Signal K along whenever daytime job permits.
-      <a href="https://github.com/tkurki/navgauge/issues/4">Started</a> with Signal K effort based on experiences
-      writing <a href="https://github.com/tkurki/navgauge">Navgauge</a>.
-    </p>
-  </li>
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Tim Mathews" src="{{site.path}}/images/tim_s.jpg" height="190" width="190">
-    </div>
-    <h4 class="name">Tim Mathews</h4>
-    <p>
-      Sailor, software engineer, tinkerer. Maintains
-      <a href="https://github.com/timmathews/argo">Argo</a> &amp;
-      <a href="https://github.com/timmathews/pyxis-web">Pyxis</a>
-    </p>
-  </li>
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Fabian Tollenaar" src="{{site.path}}/images/fabian_s.jpg" height="190" width="190">
-    </div>
-    <h4 class="name">Fabian Tollenaar</h4>
-    <p>
-      Competitive and recreational sailor from an early age.
-      Business founder and programmer, wrote Saildata which evolved into the
-      <a href="http://github.com/signalk/signalk-server-node" target="_blank">Node.js Signal K server</a>
-    </p>
-  </li>
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Kees Verruijt" src="https://avatars3.githubusercontent.com/u/1608058?v=3&s=190" height="190" width="190" />
-    </div>
-    <h4 class="name">Kees Verruijt</h4>
-    <p>
-      Started computing life building an Acorn Atom and still writes C code for a living. Maintains the
-      <a href="https://github.com/canboat/canboat">CANBoat</a> open source NMEA 2000 analyzer and the
-      <a href="https://github.com/canboat/BR24radar_pi">Navico radar plugin</a> for OpenCPN.
-    </p>
-  </li>
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Bill Bishop" src="{{site.path}}/images/bill.jpg" height="190px" width="190px" />
-    </div>
-    <h4 class="name">Bill Bishop</h4>
-    <p>
-      Sailor, boating writer, marine electronics installer with twenty five years of factory automation and robotics
-      sales management experience.
-    </p>
-  </li>
-  <li class="profile">
-    <div class="picture-wrapper">
-      <img alt="Christian Motelet" src="https://avatars1.githubusercontent.com/u/31212553?v=3&s=190" height="190px" width="190px" />
-    </div>
-    <h4 class="name">Christian Motelet</h4>
-    <p>
-      I have been sailing for 15 years, always with my own embedded system on board, which has crossed the North Atlantic.
-      First with a FoxBoard LX then an Arietta G25. In 2017, I discovered Signal K which already offered everything I needed.
-    </p>
-  </li>
+<ul>
+  <li><a href="https://github.com/orgs/SignalK/people">Team members in Github</a></li>
+  <li><a href="https://opencollective.com/signalk">Team members in Open Collective</a></li>
 </ul>
 
 <p>
-  We are all sailors, and all geeks! We work as developers and specialists in a highly connected internet world, and we
-  want to enjoy the benefits on our boats.
+There is no legal entity for Signal K. All code & artifacts are Open Source, mostly Apache 2 licensed.
 </p>
+
+<p>
+  <i><a href="mailto:info@signalk.org">info@signalk.org</a></i>
+</p>
+  

--- a/index.html
+++ b/index.html
@@ -71,5 +71,9 @@ description: "Signal K is about publishing a common modern and open data format 
     <ul class="check-list">
       <li><a href="https://opencollective.com/signalk">OpenCollective</a></li>
     </ul>
+    <h2>Contact</h2>
+    <ul>
+      <li><a href="mailto:info@signalk.org">info@signalk.org</a></li>
+    </ul>
   </div>
 </div>


### PR DESCRIPTION
The Team section no longer reflected the current situation, so replace it with links to Github and Open Collective.

Re-add info@signalk.org to the site, accidentally dropped.