### PR TITLE
Add a link to Answer Overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,7 @@ description: "Signal K is about publishing a common modern and open data format 
     <ul class="check-list">
       <li><a href="https://github.com/SignalK/signalk/discussions/">Discussions</a></li>
       <li><a href="https://discord.com/channels/1170433917761892493/1170433918592368684">Discord (chat)</a> (<a href="https://discord.gg/uuZrwz4dCS">click here for invite</a>)</li>
+      <li><a href="https://www.answeroverflow.com/c/1170433917761892493">Public index of select Discord channels</a></li>
       <li><i><a href="https://signalk-dev.slack.com">Slack</a> was replaced with Discord on 2024-02-18</i></li>
     </ul>
     <h2>Start Using Signal K</h2>


### PR DESCRIPTION
While this might be of benefit to users as well, the primary function of this link is to encourage search engines to crawl our AnswerOverflow content.