### PR TITLE
add angelnav to supported apps list

### DIFF
--- a/solutions.md
+++ b/solutions.md
@@ -26,6 +26,7 @@ description: Applications & Solutions with Signal K Support
 - [Aqua Map](http://www.globalaquamaps.com): Marine navigation app for iOS and Android with Signal K over WiFi capability.
 - [SignalK Monitor](https://www.youtube.com/watch?v=X8VbkD8WYV8): Intuitive and easy-to-use [Android](https://play.google.com/store/apps/details?id=com.belmille.signalkflutter) and [iPhone](https://apps.apple.com/fi/app/signalk-monitor/id1534189860) application to visualize SignalK data.
 - [PiCAN-M](http://skpang.co.uk/catalog/picanm-with-nmea-0183-and-nmea-2000-connection-3a-smps-p-1599.html) : Raspberry Pi hat with NMEA 2000 and NMEA 0183 connectivity with Signal K support.
+- [AngelNav](https://www.angelnav.co.uk/) : Navigation app for iPad and iPhone. Learn more at [angelnav.co.uk](https://www.angelnav.co.uk/).
 
 
 


### PR DESCRIPTION
There was an article on Yacht World June 2024 edition about GPS jamming and plotters that allow for adding manual fixes to plot position and AngelNav came up.
I peeked at the app which calls out specifically SignalK support.

https://www.angelnav.co.uk/