### PR TITLE
fix: Update links to Raspberry Pi installation markdown

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ description: "Signal K is about publishing a common modern and open data format 
     <h2>Start Using Signal K</h2>
     <ul class="check-list">
       <li><a href="{{site.path}}/overview.html">Overview</a></li>
-      <li><a href="https://github.com/SignalK/signalk-server">Signal K Server</a> on <a href="https://github.com/SignalK/signalk-server/blob/master/raspberry_pi_installation.md">Raspberry Pi</a></li>
+      <li><a href="https://github.com/SignalK/signalk-server">Signal K Server</a> on <a href="https://github.com/SignalK/signalk-server/blob/master/docs/src/installation/raspberry_pi_installation.md">Raspberry Pi</a></li>
       <li><a href="{{site.path}}/solutions.html">Apps & Solutions</a></li>
       <li><a href="{{site.path}}/references.html">Articles</a></li>
       <li><a href="{{site.path}}/gallery.html">Gallery</a></li>

--- a/installation.md
+++ b/installation.md
@@ -87,7 +87,7 @@ one of these USB cables plugged in to a 12v to USB type charging point on your b
 The Signal K server reference design is written in NodeJS and is referred to as the "Node Server", which dates back to when there was a second reference design written in Java. Unfortunately, the "Java Server" is no longer maintained and all development efforts are being focused on the "Node Server".
 
 The "Node Server" is maintained on <a href="https://github.com/signalk/signalk-server-node" target="_blank">GitHub</a> and
-a detailed “Getting Started” guide is also available - <a href="https://github.com/signalk/signalk-server-node/blob/master/raspberry_pi_installation.md" target="_blank">Signal K Node.js on Raspberry Pi</a>
+a detailed “Getting Started” guide is also available - <a href="https://github.com/SignalK/signalk-server/blob/master/docs/src/installation/raspberry_pi_installation.md" target="_blank">Signal K Node.js on Raspberry Pi</a>
 
 ## [Interfacing to Other Devices](#) <a class="anchor" id="interface"></a>
 Most equipment on boats use NMEA 0183, NMEA 2000 or proprietary interfaces to communicate with each other. A lot of


### PR DESCRIPTION
## Description

Correct links on the [Signal K home page](https://signalk.org/) and Installation markdown document for the Raspberry Pi [installation guide markdown document](https://github.com/SignalK/signalk.github.io/blob/master/installation.md) which was [moved](https://github.com/SignalK/signalk-server/commit/fc9e64d0c1e0bb7b65b8dacbeac7f0c995239980) to the docs/src/installation subdirectory.

## Screenshots
### Signal K Homepage Broken Link
https://signalk.org/

![image](https://github.com/user-attachments/assets/d3429901-c0ae-4ea6-b571-5d271e52aa72)

### Installation Guide Broken Link
https://github.com/SignalK/signalk.github.io/blob/master/installation.md

![image](https://github.com/user-attachments/assets/1035b539-f7a1-4b82-ae2e-008ce19070dc)
